### PR TITLE
Initialize Activiti Spring Boot starter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/build/
+/.gradle/
+**/*.iml
+.gradle/
+out/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("org.springframework.boot") version "3.2.0"
+    id("io.spring.dependency-management") version "1.1.4"
+    java
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_21
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.activiti:activiti-spring-boot-starter:8.2.0")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "activiti-spring-boot-starter"

--- a/src/main/java/com/example/demo/ProcessController.java
+++ b/src/main/java/com/example/demo/ProcessController.java
@@ -1,0 +1,21 @@
+package com.example.demo;
+
+import org.activiti.engine.RuntimeService;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProcessController {
+
+    private final RuntimeService runtimeService;
+
+    public ProcessController(RuntimeService runtimeService) {
+        this.runtimeService = runtimeService;
+    }
+
+    @PostMapping("/start")
+    public String startProcess() {
+        var pi = runtimeService.startProcessInstanceByKey("hello");
+        return "Started: " + pi.getId();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1
+    username: sa
+    password: 
+    driver-class-name: org.h2.Driver
+  activiti:
+    db-schema-update: true
+
+logging.level.org.activiti.engine.impl.persistence.entity: WARN

--- a/src/main/resources/processes/hello.bpmn20.xml
+++ b/src/main/resources/processes/hello.bpmn20.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+  <process id="hello" name="Hello Process" isExecutable="true">
+    <startEvent id="start" />
+    <endEvent id="end" />
+  </process>
+</definitions>

--- a/src/test/java/com/example/demo/ProcessControllerTest.java
+++ b/src/test/java/com/example/demo/ProcessControllerTest.java
@@ -1,0 +1,24 @@
+package com.example.demo;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProcessControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void startProcess() throws Exception {
+        mockMvc.perform(post("/start"))
+            .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- implement minimal Spring Boot + Activiti 8 starter
- add REST controller to start the BPMN process
- include sample BPMN, tests and Gradle build files

## Testing
- `gradle test` *(fails: plugin not found due to offline environment)*